### PR TITLE
Replace ttyS0 with ttyAMA10 to show iex shell on UART

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ This is the base Nerves System configuration for the Raspberry Pi 5 Model B.
 | GPIO, I2C, SPI       | Yes - [Elixir Circuits](https://github.com/elixir-circuits) |
 | ADC                  | No                               |
 | PWM                  | Yes, but no Elixir support       |
-| UART                 | 1 available - `ttyS0`            |
+| UART                 | 2 available - `ttyAMA10`, `ttyAMA0` |
 | Display              | HDMI or 7" RPi Touchscreen       |
 | Camera               | Official RPi Cameras (libcamera) |
 | Ethernet             | Yes                              |

--- a/config.txt
+++ b/config.txt
@@ -63,6 +63,6 @@ dtoverlay=dwc2
 # information across reboots in DRAM
 dtoverlay=ramoops
 
-# Enable the UART (/dev/ttyS0)
+# Enable the UART (/dev/ttyAMA0)
 enable_uart=1
 

--- a/rootfs_overlay/etc/erlinit.config
+++ b/rootfs_overlay/etc/erlinit.config
@@ -9,7 +9,7 @@
 
 # Specify where erlinit should send the IEx prompt. Only one may be enabled at
 # a time.
-#-c ttyS0     # UART pins on the GPIO connector
+#-c ttyAMA10  # UART connector
 -c tty1      # HDMI output
 
 # If more than one tty are available, always warn if the user is looking at the


### PR DESCRIPTION
This PR fixes #8 .

- i enabled uart by adding one line to config.txt, following is the ref for fhis
  - https://github.com/raspberrypi/documentation/issues/3239#issuecomment-1819869459
  - ref on dts, https://github.com/raspberrypi/linux/blob/stable_20231123/arch/arm/boot/dts/bcm2712-rpi-5-b.dts#L800
- i grepped and replaced `ttyS0` word with `ttyAMA0`

I confirmed this fix with building nerves system at local PC.

On the other hand, the disadvantage of this modification is that we will no longer be able to use, `ttyAMA10`, 3pin Debug UART  which exists between HDMI connectors. Because `dtparam=uart0_console` makes ttyAMA0 override it.

So what do you think about this PR? 

---

There is a document about uart, https://www.raspberrypi.com/documentation/computers/configuration.html#configuring-uarts.

(I read them roughly

- > Raspberry Pi 5 does not have mini UART.
  - mini UART is `ttyS0`
- > Raspberry Pi 5 has an additional four PL011s, which are disabled by default
  - ref. https://www.raspberrypi.com/documentation/computers/configuration.html#raspberry-pi-5
- > On the Raspberry Pi 5, /dev/serial0 is a symbolic link that points to `/dev/ttyAMA10