### PR TITLE
Vendor `build-system` job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,8 +8,114 @@ version: 2.1
 orbs:
   build-tools: nerves-project/build-tools@0.2.3
 
+jobs:
+  pre-build:
+    parameters:
+      exec:
+        type: executor
+      resource-class:
+        type: string
+        default: medium
+    executor: << parameters.exec >>
+    resource_class: << parameters.resource-class >>
+    steps:
+      - checkout
+      - build-tools/install-elixir:
+          version: $ELIXIR_VERSION
+      - build-tools/install-hex-rebar
+      - build-tools/install-nerves-bootstrap
+      - build-tools/mix-deps-get
+      - build-tools/restore-nerves-downloads
+      - run:
+          name: Create build dir
+          command: |
+            ./deps/nerves_system_br/create-build.sh nerves_defconfig build
+      - run:
+          name: make nerves-config
+          working_directory: build
+          command: make nerves-config
+      - run:
+          name: make linux
+          working_directory: build
+          command: make linux
+      - persist_to_workspace:
+          root: ~/project
+          paths:
+            - build
+            - deps
+
+  build-system:
+    parameters:
+      exec:
+        type: executor
+      resource-class:
+        type: string
+        default: medium
+      hex-validate:
+        type: boolean
+        default: true
+      env-setup:
+        type: steps
+        default: []
+    executor: << parameters.exec >>
+    resource_class: << parameters.resource-class >>
+    steps:
+      - checkout
+      - steps: << parameters.env-setup >>
+      - build-tools/install-elixir:
+          version: $ELIXIR_VERSION
+      - build-tools/install-hex-rebar
+      - build-tools/install-nerves-bootstrap
+      - build-tools/mix-deps-get
+      - build-tools/restore-nerves-downloads
+      - when:
+          condition: << parameters.hex-validate >>
+          steps:
+            - run:
+                name: Validate Hex package
+                command: mix hex.build
+      - attach_workspace:
+          at: ~/project
+      - run: 
+          name: symlink build dir
+          command: |
+            mkdir -p .nerves/artifacts
+            ln -s $PWD/build $PWD/.nerves/artifacts/nerves_system_rpi5-portable-$(< VERSION)
+      - run:
+          name: Build
+          command: mix compile
+      - run:
+          name: Did I really build
+          command: |
+            [ -d .nerves ] || (echo "VERSION file needs to be bumped or a config file needs to change to force a build"; exit 1)
+      - run:
+          name: Lint
+          command: mix nerves.system.lint nerves_defconfig
+      - run:
+          name: Create artifact dir
+          command: mkdir -p deploy/system/artifacts
+      - run:
+          name: Copy CHANGELOG
+          command: cp ./CHANGELOG.md deploy/system/CHANGELOG.md
+
+      - run:
+          name: Create artifacts
+          command: |
+            if [ -n "$CIRCLE_TAG" ]; then
+              TAG=$CIRCLE_TAG
+            else
+              TAG=$CIRCLE_SHA1
+            fi
+            mix nerves.artifact ${CIRCLE_PROJECT_REPONAME} --path deploy/system/artifacts
+      - store_artifacts:
+          path: deploy/system/artifacts
+          destination: system
+      - save_cache:
+          key: deploy/system-{{ .Revision }}-{{ .Environment.CIRCLE_TAG }}
+          paths:
+            - "deploy/system"
+
 workflows:
-  version: 2
   build_test_deploy:
     jobs:
       - build-tools/get-br-dependencies:
@@ -19,7 +125,7 @@ workflows:
           filters:
             tags:
               only: /.*/
-      - build-tools/build-system:
+      - pre-build:
           exec:
             <<: *exec
           resource-class: large
@@ -29,12 +135,25 @@ workflows:
           filters:
             tags:
               only: /.*/
+      # - build-tools/build-system:
+      - build-system:
+          exec:
+            <<: *exec
+          resource-class: large
+          context: org-global
+          requires:
+            - build-tools/get-br-dependencies
+            - pre-build
+          filters:
+            tags:
+              only: /.*/
       - build-tools/deploy-system:
           exec:
             <<: *exec
           context: org-global
           requires:
-            - build-tools/build-system
+            # - build-tools/build-system
+            - build-system
           filters:
             branches:
               ignore: /.*/


### PR DESCRIPTION
This build is running steps that exceed the CircleCI 1-hour limit. To help that, this breaks out `build-system` into a custom job where we attempt to `make` pieces individually to separate out the time of build steps to hopefully get past 1-hour limits