### PR TITLE
Add missing overlay needed for the CM5

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -40,6 +40,9 @@ file-resource bcm2712-rpi-cm5l-cm5io.dtb {
 file-resource overlay_map.dtb {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/overlay_map.dtb"
 }
+file-resource bcm2712d0.dtbo {
+    host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/bcm2712d0.dtbo"
+}
 file-resource rpi-ft5406.dtbo {
     host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/rpi-ft5406.dtbo"
 }
@@ -196,6 +199,7 @@ task complete {
     on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
     on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
     on-resource overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
@@ -284,6 +288,7 @@ task upgrade.a {
     on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
     on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
     on-resource overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
@@ -380,6 +385,7 @@ task upgrade.b {
     on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
     on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
     on-resource overlay_map.dtb { fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb") }
+    on-resource bcm2712d0.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }


### PR DESCRIPTION
This was found by running `vclog --msg` on a booting image and seeing
that `bcm2712d0.dtbo` was being loaded. The docs says that this overlay
has the differences from the c0 silicon that seems to be on all of the
regular RPi 5's right now.
