### PR TITLE
add support for one wire on the pi5

### DIFF
--- a/config.txt
+++ b/config.txt
@@ -54,7 +54,7 @@ arm_boost=1
 # Comment this in or modify to enable OneWire
 # NOTE: check that the overlay that you specify is in the boot partition or
 #       this won't work.
-#dtoverlay=w1-gpio-pullup,gpiopin=4
+#dtoverlay=w1-gpio-pi5,gpiopin=4
 
 # Support USB gadget mode on the USB-C port
 dtoverlay=dwc2

--- a/fwup.conf
+++ b/fwup.conf
@@ -47,6 +47,9 @@ file-resource vc4-kms-dsi-ili9881-7inch.dtbo { host-path = "${NERVES_SYSTEM}/ima
 file-resource vc4-kms-v3d.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d.dtbo" }
 file-resource vc4-kms-v3d-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d-pi5.dtbo" }
 file-resource w1-gpio-pullup.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup.dtbo" }
+file-resource w1-gpio-pullup-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup-pi5.dtbo" }
+file-resource w1-gpio.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio.dtbo" }
+file-resource w1-gpio-pi5.dtbo { host-path = "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pi5.dtbo" }
 
 file-resource rootfs.img {
     host-path = ${ROOTFS}
@@ -152,6 +155,9 @@ task complete {
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource w1-gpio-pullup-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo") }
+    on-resource w1-gpio.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
+    on-resource w1-gpio-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
     on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
@@ -242,6 +248,9 @@ task upgrade.a {
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource w1-gpio-pullup-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo") }
+    on-resource w1-gpio.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
+    on-resource w1-gpio-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
     on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
@@ -340,6 +349,9 @@ task upgrade.b {
     on-resource rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
     on-resource rpi-backlight.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
     on-resource w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
+    on-resource w1-gpio-pullup-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo") }
+    on-resource w1-gpio-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo") }
+    on-resource w1-gpio.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
     on-resource miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
     on-resource vc4-kms-v3d.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
     on-resource vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }


### PR DESCRIPTION
Adds the 1-gpio-pullup-pi5.dtbo, w1-gpio.dtbo and w1-gpio-pi5.dtbo to the list of resources. Without them the w1 overlay does not load correctly 