### PR TITLE
Reduce fwup redundancy by using an EEx template

### DIFF
--- a/REUSE.toml
+++ b/REUSE.toml
@@ -56,6 +56,7 @@ SPDX-License-Identifier = "GPL-2.0-only"
 path = [
  "fwup-ops.conf",
  "fwup.conf",
+ "fwup.conf.eex",
  "fwup_include/*"
 ]
 precedence = "aggregate"

--- a/fwup.conf
+++ b/fwup.conf
@@ -1,5 +1,8 @@
 # Firmware configuration file for the Raspberry Pi 5
-
+#
+# IMPORTANT:
+# Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
+#
 require-fwup-version="0.15.0"  # For the trim() call
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
@@ -89,10 +92,10 @@ task complete {
         uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
     }
 
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
     on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
@@ -183,10 +186,10 @@ task upgrade.a {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
+    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
+    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
     on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
     on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
@@ -246,10 +249,10 @@ task upgrade.a {
         uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
-	# Switch over to boot the new firmware
-	# NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
-	#       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
-	#       other code.
+        # Switch over to boot the new firmware
+        # NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
+        #       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
+        #       other code.
         uboot_setenv(uboot-env, "nerves_fw_active", "a")
         uboot_setenv(uboot-env, "a.nerves_fw_validated", "1")
         mbr_write(mbr-a)
@@ -289,10 +292,10 @@ task upgrade.b {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
+    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
+    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
     on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
     on-resource cmdline.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
-    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
     on-resource kernel8.img { fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img") }
     on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
     on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
@@ -352,10 +355,10 @@ task upgrade.b {
         uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
         uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
 
-	# Switch over to boot the new firmware
-	# NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
-	#       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
-	#       other code.
+        # Switch over to boot the new firmware
+        # NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
+        #       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
+        #       other code.
         uboot_setenv(uboot-env, "nerves_fw_active", "b")
         uboot_setenv(uboot-env, "b.nerves_fw_validated", "1")
         mbr_write(mbr-b)

--- a/fwup.conf.eex
+++ b/fwup.conf.eex
@@ -1,0 +1,281 @@
+# Firmware configuration file for the Raspberry Pi 5
+#
+# IMPORTANT:
+# Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
+#
+require-fwup-version="0.15.0"  # For the trim() call
+
+include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
+<%
+# Define file resources - order matters for firmware update
+file_resources = [
+  %{name: "fixup4.dat", path: "${NERVES_SYSTEM}/images/rpi-firmware/fixup4x.dat"},
+  %{name: "start4.elf", path: "${NERVES_SYSTEM}/images/rpi-firmware/start4x.elf"},
+  %{name: "config.txt", path: "${NERVES_SYSTEM}/images/config.txt"},
+  %{name: "cmdline.txt", path: "${NERVES_SYSTEM}/images/cmdline.txt"},
+  %{name: "kernel8.img", path: "${NERVES_SYSTEM}/images/Image"},
+  %{name: "bcm2712-rpi-5-b.dtb", path: "${NERVES_SYSTEM}/images/bcm2712-rpi-5-b.dtb"},
+  %{name: "bcm2712-rpi-cm5-cm4io.dtb", path: "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5-cm4io.dtb"},
+  %{name: "bcm2712-rpi-cm5-cm5io.dtb", path: "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5-cm5io.dtb"},
+  %{name: "bcm2712-rpi-cm5l-cm4io.dtb", path: "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5l-cm4io.dtb"},
+  %{name: "bcm2712-rpi-cm5l-cm5io.dtb", path: "${NERVES_SYSTEM}/images/bcm2712-rpi-cm5l-cm5io.dtb"},
+  %{name: "overlays/bcm2712d0.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/bcm2712d0.dtbo"},
+  %{name: "overlays/dwc2.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/dwc2.dtbo"},
+  %{name: "overlays/i2c-mux.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c-mux.dtbo"},
+  %{name: "overlays/i2c0-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c0-pi5.dtbo"},
+  %{name: "overlays/i2c1-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c1-pi5.dtbo"},
+  %{name: "overlays/i2c2-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c2-pi5.dtbo"},
+  %{name: "overlays/i2c3-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/i2c3-pi5.dtbo"},
+  %{name: "overlays/imx219.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx219.dtbo"},
+  %{name: "overlays/imx296.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx296.dtbo"},
+  %{name: "overlays/imx477.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx477.dtbo"},
+  %{name: "overlays/imx708.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/imx708.dtbo"},
+  %{name: "overlays/miniuart-bt.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/miniuart-bt.dtbo"},
+  %{name: "overlays/ov5647.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/ov5647.dtbo"},
+  %{name: "overlays/overlay_map.dtb", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/overlay_map.dtb"},
+  %{name: "overlays/ramoops-pi4.dtbo", path: "${NERVES_SYSTEM}/images/ramoops-pi4-overlay.dtb"},
+  %{name: "overlays/rpi-backlight.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/rpi-backlight.dtbo"},
+  %{name: "overlays/rpi-ft5406.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/rpi-ft5406.dtbo"},
+  %{name: "overlays/tc358743.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/tc358743.dtbo"},
+  %{name: "overlays/uart0-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart0-pi5.dtbo"},
+  %{name: "overlays/uart1-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart1-pi5.dtbo"},
+  %{name: "overlays/uart2-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart2-pi5.dtbo"},
+  %{name: "overlays/uart3-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart3-pi5.dtbo"},
+  %{name: "overlays/uart4-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/uart4-pi5.dtbo"},
+  %{name: "overlays/vc4-kms-dsi-7inch.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-dsi-7inch.dtbo"},
+  %{name: "overlays/vc4-kms-dsi-ili9881-7inch.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-dsi-ili9881-7inch.dtbo"},
+  %{name: "overlays/vc4-kms-v3d.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d.dtbo"},
+  %{name: "overlays/vc4-kms-v3d-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/vc4-kms-v3d-pi5.dtbo"},
+  %{name: "overlays/w1-gpio.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio.dtbo"},
+  %{name: "overlays/w1-gpio-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pi5.dtbo"},
+  %{name: "overlays/w1-gpio-pullup.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup.dtbo"},
+  %{name: "overlays/w1-gpio-pullup-pi5.dtbo", path: "${NERVES_SYSTEM}/images/rpi-firmware/overlays/w1-gpio-pullup-pi5.dtbo"},
+]
+%>
+# File resources are listed in the order that they are included in the .fw file
+# This is important, since this is the order that they're written on a firmware
+# update due to the event driven nature of the update system.
+<%= for resource <- file_resources do %>file-resource <%= resource.name %> { host-path = "<%= resource.path %>" }
+<% end %>
+file-resource rootfs.img {
+    host-path = ${ROOTFS}
+
+    # Error out if the rootfs size exceeds the partition size
+    assert-size-lte = ${ROOTFS_A_PART_COUNT}
+}
+
+# This firmware task writes everything to the destination media
+task complete {
+    # Only match if not mounted
+    require-unmounted-destination = true
+
+    on-init {
+        mbr_write(mbr-a)
+
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        uboot_clearenv(uboot-env)
+
+        include("${NERVES_PROVISIONING}")
+
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        uboot_setenv(uboot-env, "nerves_fw_devpath", ${NERVES_FW_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "1")
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+    }
+
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>") }
+<% end %>
+    on-resource rootfs.img {
+        # write to the first rootfs partition
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Clear out any old data in the B partition that might be mistaken for
+        # a file system. This is mostly to avoid confusion in humans when
+        # reprogramming SDCards with unknown contents.
+        raw_memset(${BOOT_B_PART_OFFSET}, 256, 0xff)
+        raw_memset(${ROOTFS_B_PART_OFFSET}, 256, 0xff)
+
+        # Invalidate the application data partition so that it is guaranteed to
+        # trigger the corrupt filesystem detection code on first boot and get
+        # formatted. If this isn't done and an old SDCard is reused, the
+        # application data could be in a weird state.
+        raw_memset(${APP_PART_OFFSET}, 256, 0xff)
+    }
+}
+
+task upgrade.a {
+    # This task upgrades the A partition
+    require-partition-offset(1, ${ROOTFS_B_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "b.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "b.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition A")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway. If this partition was bootable, it's not going to
+        # be soon.
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "0")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "a.nerves_fw_uuid")
+
+        # Reset the previous contents of the A boot partition
+        fat_mkfs(${BOOT_A_PART_OFFSET}, ${BOOT_A_PART_COUNT})
+        fat_setlabel(${BOOT_A_PART_OFFSET}, "BOOT-A")
+        fat_mkdir(${BOOT_A_PART_OFFSET}, "overlays")
+
+        # Indicate that the entire partition can be cleared
+        trim(${ROOTFS_A_PART_OFFSET}, ${ROOTFS_A_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the B partition, so an error or power failure during this part
+    # won't hurt anything.
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>") }
+<% end %>
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_B_PART_COUNT}
+        raw_write(${ROOTFS_A_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "a.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "a.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "a.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "a.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "a.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "a.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "a.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "a.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "a.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "a.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+        # Switch over to boot the new firmware
+        # NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
+        #       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
+        #       other code.
+        uboot_setenv(uboot-env, "nerves_fw_active", "a")
+        uboot_setenv(uboot-env, "a.nerves_fw_validated", "1")
+        mbr_write(mbr-a)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.b {
+    # This task upgrades the B partition
+    require-partition-offset(1, ${ROOTFS_A_PART_OFFSET})
+
+    # Verify the expected platform/architecture
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+
+    on-init {
+        info("Upgrading partition B")
+
+        # Clear some firmware information just in case this update gets
+        # interrupted midway.
+        uboot_setenv(uboot-env, "b.nerves_fw_validated", "0")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_version")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_platform")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_architecture")
+        uboot_unsetenv(uboot-env, "b.nerves_fw_uuid")
+
+        # Reset the previous contents of the B boot partition
+        fat_mkfs(${BOOT_B_PART_OFFSET}, ${BOOT_B_PART_COUNT})
+        fat_setlabel(${BOOT_B_PART_OFFSET}, "BOOT-B")
+        fat_mkdir(${BOOT_B_PART_OFFSET}, "overlays")
+
+        trim(${ROOTFS_B_PART_OFFSET}, ${ROOTFS_B_PART_COUNT})
+    }
+
+    # Write the new boot partition files and rootfs. The MBR still points
+    # to the A partition, so an error or power failure during this part
+    # won't hurt anything.
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>") }
+<% end %>
+    on-resource rootfs.img {
+        delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}
+        delta-source-raw-count=${ROOTFS_A_PART_COUNT}
+        raw_write(${ROOTFS_B_PART_OFFSET})
+    }
+
+    on-finish {
+        # Update firmware metadata
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_devpath", ${NERVES_FW_APPLICATION_PART0_DEVPATH})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_fstype", ${NERVES_FW_APPLICATION_PART0_FSTYPE})
+        uboot_setenv(uboot-env, "b.nerves_fw_application_part0_target", ${NERVES_FW_APPLICATION_PART0_TARGET})
+        uboot_setenv(uboot-env, "b.nerves_fw_product", ${NERVES_FW_PRODUCT})
+        uboot_setenv(uboot-env, "b.nerves_fw_description", ${NERVES_FW_DESCRIPTION})
+        uboot_setenv(uboot-env, "b.nerves_fw_version", ${NERVES_FW_VERSION})
+        uboot_setenv(uboot-env, "b.nerves_fw_platform", ${NERVES_FW_PLATFORM})
+        uboot_setenv(uboot-env, "b.nerves_fw_architecture", ${NERVES_FW_ARCHITECTURE})
+        uboot_setenv(uboot-env, "b.nerves_fw_author", ${NERVES_FW_AUTHOR})
+        uboot_setenv(uboot-env, "b.nerves_fw_vcs_identifier", ${NERVES_FW_VCS_IDENTIFIER})
+        uboot_setenv(uboot-env, "b.nerves_fw_misc", ${NERVES_FW_MISC})
+        uboot_setenv(uboot-env, "b.nerves_fw_uuid", "\${FWUP_META_UUID}")
+
+        # Switch over to boot the new firmware
+        # NOTE: The mbr_write is the important step. Automatic fallback is not supported, so
+        #       setting the variables is a formality for Nerves.Runtime.firmware_validation_status and
+        #       other code.
+        uboot_setenv(uboot-env, "nerves_fw_active", "b")
+        uboot_setenv(uboot-env, "b.nerves_fw_validated", "1")
+        mbr_write(mbr-b)
+    }
+
+    on-error {
+    }
+}
+
+task upgrade.unexpected {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        error("Please check the media being upgraded. It doesn't look like either the A or B partitions are active.")
+    }
+}
+
+task upgrade.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}
+
+task provision {
+    require-uboot-variable(uboot-env, "a.nerves_fw_platform", "${NERVES_FW_PLATFORM}")
+    require-uboot-variable(uboot-env, "a.nerves_fw_architecture", "${NERVES_FW_ARCHITECTURE}")
+    on-init {
+        include("${NERVES_PROVISIONING}")
+    }
+}
+task provision.wrongplatform {
+    on-init {
+        error("Expecting platform=${NERVES_FW_PLATFORM} and architecture=${NERVES_FW_ARCHITECTURE}")
+    }
+}

--- a/mix.exs
+++ b/mix.exs
@@ -19,7 +19,10 @@ defmodule NervesSystemRpi5.MixProject do
       description: description(),
       package: package(),
       deps: deps(),
-      aliases: [loadconfig: [&bootstrap/1]],
+      aliases: [
+        loadconfig: [&bootstrap/1],
+        generate_fwup_conf: &generate_fwup_conf/1
+      ],
       docs: docs()
     ]
   end
@@ -109,6 +112,7 @@ defmodule NervesSystemRpi5.MixProject do
       "cmdline.txt",
       "config.txt",
       "fwup-ops.conf",
+      "fwup.conf.eex",
       "fwup.conf",
       "LICENSES/*",
       "linux-6.12.defconfig",
@@ -141,5 +145,16 @@ defmodule NervesSystemRpi5.MixProject do
     else
       System.put_env("MIX_TARGET", "target")
     end
+  end
+
+  defp generate_fwup_conf(_args) do
+    template_path = Path.join(__DIR__, "fwup.conf.eex")
+    output_path = Path.join(__DIR__, "fwup.conf")
+
+    Mix.shell().info("Generating fwup.conf")
+
+    content = EEx.eval_file(template_path)
+    File.write!(output_path, content)
+    Mix.shell().info("Successfully generated #{output_path}")
   end
 end


### PR DESCRIPTION
The final fwup.conf file is still being committed to allow time to grow
trust in using a template language to generate the fwup.conf.

This refactor is really needed for TRYBOOT support due to significantly
more fwup.conf redundancy to migrate pre-TRYBOOT devices.
