### PR TITLE
Add delta update support for boot partition files

### DIFF
--- a/fwup.conf
+++ b/fwup.conf
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -420,48 +420,212 @@ task upgrade.a {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource start4.elf {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="start4.elf"
+        fat_write(${BOOT_A_PART_OFFSET}, "start4.elf")
+    }
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-    on-resource fixup4.dat { fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat") }
-    on-resource config.txt { fat_write(${BOOT_A_PART_OFFSET}, "config.txt") }
-    on-resource kernel8.img { fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img") }
-    on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
-    on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
-    on-resource bcm2712-rpi-cm5-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb") }
-    on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
-    on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
-    on-resource overlays/bcm2712d0.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
-    on-resource overlays/dwc2.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/i2c0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c0-pi5.dtbo") }
-    on-resource overlays/i2c1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c1-pi5.dtbo") }
-    on-resource overlays/i2c2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c2-pi5.dtbo") }
-    on-resource overlays/i2c3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c3-pi5.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/overlay_map.dtb { fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb") }
-    on-resource overlays/ramoops-pi4.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops-pi4.dtbo") }
-    on-resource overlays/rpi-backlight.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
-    on-resource overlays/rpi-ft5406.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/uart0-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart0-pi5.dtbo") }
-    on-resource overlays/uart1-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart1-pi5.dtbo") }
-    on-resource overlays/uart2-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart2-pi5.dtbo") }
-    on-resource overlays/uart3-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart3-pi5.dtbo") }
-    on-resource overlays/uart4-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart4-pi5.dtbo") }
-    on-resource overlays/vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-5inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-5inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo") }
-    on-resource overlays/vc4-kms-v3d.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
-    on-resource overlays/vc4-kms-v3d-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo") }
-    on-resource overlays/w1-gpio.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
-    on-resource overlays/w1-gpio-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
-    on-resource overlays/w1-gpio-pullup-pi5.dtbo { fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo") }
+    on-resource fixup4.dat {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="fixup4.dat"
+        fat_write(${BOOT_A_PART_OFFSET}, "fixup4.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_A_PART_OFFSET}, "config.txt")
+    }
+    on-resource kernel8.img {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="kernel8.img"
+        fat_write(${BOOT_A_PART_OFFSET}, "kernel8.img")
+    }
+    on-resource bcm2712-rpi-5-b.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-5-b.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-5-b.dtb")
+    }
+    on-resource bcm2712-rpi-cm5-cm4io.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5-cm4io.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5-cm5io.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5-cm5io.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5l-cm4io.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5l-cm4io.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5l-cm5io.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5l-cm5io.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb")
+    }
+    on-resource overlays/bcm2712d0.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/bcm2712d0.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/bcm2712d0.dtbo")
+    }
+    on-resource overlays/dwc2.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/dwc2.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/dwc2.dtbo")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/i2c0-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c0-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c0-pi5.dtbo")
+    }
+    on-resource overlays/i2c1-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c1-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c1-pi5.dtbo")
+    }
+    on-resource overlays/i2c2-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c2-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c2-pi5.dtbo")
+    }
+    on-resource overlays/i2c3-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c3-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/i2c3-pi5.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/overlay_map.dtb {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/overlay_map.dtb"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/overlay_map.dtb")
+    }
+    on-resource overlays/ramoops-pi4.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops-pi4.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/ramoops-pi4.dtbo")
+    }
+    on-resource overlays/rpi-backlight.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-backlight.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-backlight.dtbo")
+    }
+    on-resource overlays/rpi-ft5406.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-ft5406.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/rpi-ft5406.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/uart0-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/uart0-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart0-pi5.dtbo")
+    }
+    on-resource overlays/uart1-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/uart1-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart1-pi5.dtbo")
+    }
+    on-resource overlays/uart2-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/uart2-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart2-pi5.dtbo")
+    }
+    on-resource overlays/uart3-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/uart3-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart3-pi5.dtbo")
+    }
+    on-resource overlays/uart4-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/uart4-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/uart4-pi5.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-7inch.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-5inch.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-5inch.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-5inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo")
+    }
+    on-resource overlays/w1-gpio.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio.dtbo")
+    }
+    on-resource overlays/w1-gpio-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup-pi5.dtbo"
+        fat_write(${BOOT_A_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -526,48 +690,212 @@ task upgrade.b {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
-    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
+    on-resource start4.elf {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="start4.elf"
+        fat_write(${BOOT_B_PART_OFFSET}, "start4.elf")
+    }
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-    on-resource fixup4.dat { fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat") }
-    on-resource config.txt { fat_write(${BOOT_B_PART_OFFSET}, "config.txt") }
-    on-resource kernel8.img { fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img") }
-    on-resource bcm2712-rpi-5-b.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-5-b.dtb") }
-    on-resource bcm2712-rpi-cm5-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb") }
-    on-resource bcm2712-rpi-cm5-cm5io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb") }
-    on-resource bcm2712-rpi-cm5l-cm4io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb") }
-    on-resource bcm2712-rpi-cm5l-cm5io.dtb { fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb") }
-    on-resource overlays/bcm2712d0.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/bcm2712d0.dtbo") }
-    on-resource overlays/dwc2.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo") }
-    on-resource overlays/i2c-mux.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo") }
-    on-resource overlays/i2c0-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c0-pi5.dtbo") }
-    on-resource overlays/i2c1-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c1-pi5.dtbo") }
-    on-resource overlays/i2c2-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c2-pi5.dtbo") }
-    on-resource overlays/i2c3-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c3-pi5.dtbo") }
-    on-resource overlays/imx219.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo") }
-    on-resource overlays/imx296.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo") }
-    on-resource overlays/imx477.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo") }
-    on-resource overlays/imx708.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo") }
-    on-resource overlays/miniuart-bt.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo") }
-    on-resource overlays/ov5647.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo") }
-    on-resource overlays/overlay_map.dtb { fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb") }
-    on-resource overlays/ramoops-pi4.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops-pi4.dtbo") }
-    on-resource overlays/rpi-backlight.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo") }
-    on-resource overlays/rpi-ft5406.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo") }
-    on-resource overlays/tc358743.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo") }
-    on-resource overlays/uart0-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart0-pi5.dtbo") }
-    on-resource overlays/uart1-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart1-pi5.dtbo") }
-    on-resource overlays/uart2-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart2-pi5.dtbo") }
-    on-resource overlays/uart3-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart3-pi5.dtbo") }
-    on-resource overlays/uart4-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart4-pi5.dtbo") }
-    on-resource overlays/vc4-kms-dsi-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-5inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-5inch.dtbo") }
-    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo") }
-    on-resource overlays/vc4-kms-v3d.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo") }
-    on-resource overlays/vc4-kms-v3d-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo") }
-    on-resource overlays/w1-gpio.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio.dtbo") }
-    on-resource overlays/w1-gpio-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo") }
-    on-resource overlays/w1-gpio-pullup.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo") }
-    on-resource overlays/w1-gpio-pullup-pi5.dtbo { fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo") }
+    on-resource fixup4.dat {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="fixup4.dat"
+        fat_write(${BOOT_B_PART_OFFSET}, "fixup4.dat")
+    }
+    on-resource config.txt {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="config.txt"
+        fat_write(${BOOT_B_PART_OFFSET}, "config.txt")
+    }
+    on-resource kernel8.img {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="kernel8.img"
+        fat_write(${BOOT_B_PART_OFFSET}, "kernel8.img")
+    }
+    on-resource bcm2712-rpi-5-b.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-5-b.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-5-b.dtb")
+    }
+    on-resource bcm2712-rpi-cm5-cm4io.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5-cm4io.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm4io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5-cm5io.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5-cm5io.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5-cm5io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5l-cm4io.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5l-cm4io.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm4io.dtb")
+    }
+    on-resource bcm2712-rpi-cm5l-cm5io.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="bcm2712-rpi-cm5l-cm5io.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "bcm2712-rpi-cm5l-cm5io.dtb")
+    }
+    on-resource overlays/bcm2712d0.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/bcm2712d0.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/bcm2712d0.dtbo")
+    }
+    on-resource overlays/dwc2.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/dwc2.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/dwc2.dtbo")
+    }
+    on-resource overlays/i2c-mux.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c-mux.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c-mux.dtbo")
+    }
+    on-resource overlays/i2c0-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c0-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c0-pi5.dtbo")
+    }
+    on-resource overlays/i2c1-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c1-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c1-pi5.dtbo")
+    }
+    on-resource overlays/i2c2-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c2-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c2-pi5.dtbo")
+    }
+    on-resource overlays/i2c3-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/i2c3-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/i2c3-pi5.dtbo")
+    }
+    on-resource overlays/imx219.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx219.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx219.dtbo")
+    }
+    on-resource overlays/imx296.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx296.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx296.dtbo")
+    }
+    on-resource overlays/imx477.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx477.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx477.dtbo")
+    }
+    on-resource overlays/imx708.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/imx708.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/imx708.dtbo")
+    }
+    on-resource overlays/miniuart-bt.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/miniuart-bt.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/miniuart-bt.dtbo")
+    }
+    on-resource overlays/ov5647.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ov5647.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ov5647.dtbo")
+    }
+    on-resource overlays/overlay_map.dtb {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/overlay_map.dtb"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/overlay_map.dtb")
+    }
+    on-resource overlays/ramoops-pi4.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/ramoops-pi4.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/ramoops-pi4.dtbo")
+    }
+    on-resource overlays/rpi-backlight.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-backlight.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-backlight.dtbo")
+    }
+    on-resource overlays/rpi-ft5406.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/rpi-ft5406.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/rpi-ft5406.dtbo")
+    }
+    on-resource overlays/tc358743.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/tc358743.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/tc358743.dtbo")
+    }
+    on-resource overlays/uart0-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/uart0-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart0-pi5.dtbo")
+    }
+    on-resource overlays/uart1-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/uart1-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart1-pi5.dtbo")
+    }
+    on-resource overlays/uart2-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/uart2-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart2-pi5.dtbo")
+    }
+    on-resource overlays/uart3-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/uart3-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart3-pi5.dtbo")
+    }
+    on-resource overlays/uart4-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/uart4-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/uart4-pi5.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-7inch.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-5inch.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-5inch.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-5inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-dsi-ili9881-7inch.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-dsi-ili9881-7inch.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-dsi-ili9881-7inch.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d.dtbo")
+    }
+    on-resource overlays/vc4-kms-v3d-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/vc4-kms-v3d-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/vc4-kms-v3d-pi5.dtbo")
+    }
+    on-resource overlays/w1-gpio.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio.dtbo")
+    }
+    on-resource overlays/w1-gpio-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pi5.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup.dtbo")
+    }
+    on-resource overlays/w1-gpio-pullup-pi5.dtbo {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="overlays/w1-gpio-pullup-pi5.dtbo"
+        fat_write(${BOOT_B_PART_OFFSET}, "overlays/w1-gpio-pullup-pi5.dtbo")
+    }
 
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}

--- a/fwup.conf.eex
+++ b/fwup.conf.eex
@@ -3,7 +3,7 @@
 # IMPORTANT:
 # Edit `fwup.conf.eex` and run `mix generate_fwup_conf` to generate fwup.conf.
 #
-require-fwup-version="1.0.0"
+require-fwup-version="1.12.0"
 
 include("${NERVES_SDK_IMAGES:-.}/fwup_include/fwup-common.conf")
 
@@ -308,9 +308,17 @@ task upgrade.a {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the B partition, so an error or power failure during this part
     # won't hurt anything.
-    on-resource start4.elf { fat_write(${BOOT_A_PART_OFFSET}, "start4.elf") }
+    on-resource start4.elf {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="start4.elf"
+        fat_write(${BOOT_A_PART_OFFSET}, "start4.elf")
+    }
     on-resource cmdline-a.txt { fat_write(${BOOT_A_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_B_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_A_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_B_PART_OFFSET}
@@ -375,9 +383,17 @@ task upgrade.b {
     # Write the new boot partition files and rootfs. The MBR still points
     # to the A partition, so an error or power failure during this part
     # won't hurt anything.
-    on-resource start4.elf { fat_write(${BOOT_B_PART_OFFSET}, "start4.elf") }
+    on-resource start4.elf {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="start4.elf"
+        fat_write(${BOOT_B_PART_OFFSET}, "start4.elf")
+    }
     on-resource cmdline-b.txt { fat_write(${BOOT_B_PART_OFFSET}, "cmdline.txt") }
-<%= for resource <- file_resources do %>    on-resource <%= resource.name %> { fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>") }
+<%= for resource <- file_resources do %>    on-resource <%= resource.name %> {
+        delta-source-fat-offset=${BOOT_A_PART_OFFSET}
+        delta-source-fat-path="<%= resource.name %>"
+        fat_write(${BOOT_B_PART_OFFSET}, "<%= resource.name %>")
+    }
 <% end %>
     on-resource rootfs.img {
         delta-source-raw-offset=${ROOTFS_A_PART_OFFSET}


### PR DESCRIPTION
cmdline.txt is excluded since the copy on the other boot partition is
the other slot's variant.

Bump require-fwup-version to 1.12.0.